### PR TITLE
configure secret log visibility

### DIFF
--- a/generic-pretty-instances/generic-pretty-instances.cabal
+++ b/generic-pretty-instances/generic-pretty-instances.cabal
@@ -28,7 +28,9 @@ source-repository head
 
 library
   exposed-modules:
+      Text.PrettyPrint.GenericPretty.Import
       Text.PrettyPrint.GenericPretty.Instance
+      Text.PrettyPrint.GenericPretty.Type
       Text.PrettyPrint.GenericPretty.Util
   other-modules:
       Paths_generic_pretty_instances
@@ -41,6 +43,7 @@ library
       StrictData
       DeriveGeneric
       DerivingStrategies
+      LambdaCase
   ghc-options: -Weverything -Werror -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures
   build-depends:
       GenericPretty
@@ -66,7 +69,9 @@ test-suite generic-pretty-instances-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Text.PrettyPrint.GenericPretty.Import
       Text.PrettyPrint.GenericPretty.Instance
+      Text.PrettyPrint.GenericPretty.Type
       Text.PrettyPrint.GenericPretty.Util
       GenericPrettyInstancesSpec
       Paths_generic_pretty_instances
@@ -80,6 +85,7 @@ test-suite generic-pretty-instances-test
       StrictData
       DeriveGeneric
       DerivingStrategies
+      LambdaCase
   ghc-options: -Weverything -Werror -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       GenericPretty

--- a/generic-pretty-instances/package.yaml
+++ b/generic-pretty-instances/package.yaml
@@ -45,6 +45,7 @@ default-extensions:
 - StrictData
 - DeriveGeneric
 - DerivingStrategies
+- LambdaCase
 
 ghc-options:
 # For details on warnings: https://downloads.haskell.org/~ghc/master/users-guide/using-warnings.html

--- a/generic-pretty-instances/src/Text/PrettyPrint/GenericPretty/Import.hs
+++ b/generic-pretty-instances/src/Text/PrettyPrint/GenericPretty/Import.hs
@@ -1,0 +1,8 @@
+module Text.PrettyPrint.GenericPretty.Import
+  ( module X,
+  )
+where
+
+import Text.PrettyPrint.GenericPretty.Instance as X ()
+import Text.PrettyPrint.GenericPretty.Type as X
+import Text.PrettyPrint.GenericPretty.Util as X

--- a/generic-pretty-instances/src/Text/PrettyPrint/GenericPretty/Type.hs
+++ b/generic-pretty-instances/src/Text/PrettyPrint/GenericPretty/Type.hs
@@ -1,0 +1,30 @@
+module Text.PrettyPrint.GenericPretty.Type
+  ( PrettyLog (..),
+    SecretVision (..),
+  )
+where
+
+import Text.PrettyPrint.GenericPretty (Out (..))
+import Universum
+
+data PrettyLog a
+  = PrettyLog a
+  | SecretLog SecretVision a
+  deriving stock (Eq, Ord)
+
+data SecretVision
+  = SecretVisible
+  | SecretHidden
+  deriving stock (Eq, Ord, Show, Read, Generic)
+
+instance Out SecretVision
+
+instance (Out a) => Out (PrettyLog a) where
+  docPrec n = \case
+    PrettyLog x -> docPrec n x
+    SecretLog SecretVisible x -> docPrec n x
+    SecretLog SecretHidden _ -> "SECRET"
+  doc = \case
+    PrettyLog x -> doc x
+    SecretLog SecretVisible x -> doc x
+    SecretLog SecretHidden _ -> "SECRET"


### PR DESCRIPTION
PrettyLog and SecretVision types to control logging of secret types which we don't control much (for example auto-gen from proto-lens)